### PR TITLE
Add djb2a implemenation which uses xor over +

### DIFF
--- a/README
+++ b/README
@@ -10,3 +10,4 @@ It includes:
     SQLite3
     SuperFastHash
     djb2
+    djb2a

--- a/hashes_test.go
+++ b/hashes_test.go
@@ -84,6 +84,40 @@ var goldenDjb32 = []_Golden{
 	{0x9f8d455a, "How can you write a big system without C++?  -Paul Glick"},
 }
 
+var goldenDjb32a = []_Golden{
+	{0x00001505, ""},
+	{0x0002b5c4, "a"},
+	{0x00596e26, "ab"},
+	{0x0b873285, "abc"},
+	{0x7c6d8341, "abcd"},
+	{0x0a1deb04, "abcde"},
+	{0x4ddb4be2, "abcdef"},
+	{0x0944c845, "abcdefg"},
+	{0x31ddd08d, "abcdefgh"},
+	{0x6d97e244, "abcdefghi"},
+	{0x20942aae, "abcdefghij"},
+	{0x61cc0ef4, "Discard medicine more than two years old."},
+	{0x78d05b1b, "He who has a shady past knows that nice guys finish last."},
+	{0x5784addb, "I wouldn't marry him with a ten foot pole."},
+	{0xcdaf4d3f, "Free! Free!/A trip/to Mars/for 900/empty jars/Burma Shave"},
+	{0xff825f4e, "The days of the digital watch are numbered.  -Tom Stoppard"},
+	{0x2dca1828, "Nepal premier won't resign."},
+	{0xa868a825, "For every action there is an equal and opposite government program."},
+	{0x8d5626a4, "His money is twice tainted: 'taint yours and 'taint mine."},
+	{0x759731a1, "There is no reason for any individual to have a computer in their home. -Ken Olsen, 1977"},
+	{0x2d10a0cc, "It's a tiny change to the code and not completely disgusting. - Bob Manchek"},
+	{0x217bca27, "size:  a.out:  bad magic"},
+	{0xab9f58d7, "The major problem is with sendmail.  -Mark Horton"},
+	{0x2c8605b0, "Give me a rock, paper and scissors and I will move the world.  CCFestoon"},
+	{0xe15bd3d5, "If the enemy is within range, then so are you."},
+	{0xce4c97cf, "It's well we cannot hear the screams/That we create in others' dreams."},
+	{0xceb1e23d, "You remind me of a TV show, but that's all right: I watch it anyway."},
+	{0x006fd4a7, "C is as portable as Stonehedge!!"},
+	{0xd6911f62, "Even if I could be Shakespeare, I think I should still choose to be Faraday. - A. Huxley"},
+	{0x3290cdb7, "The fugacity of a constituent in a mixture of gases at a given temperature is proportional to its mole fraction.  Lewis-Randall Rule"},
+	{0x7c8e18d0, "How can you write a big system without C++?  -Paul Glick"},
+}
+
 var goldenElf32 = []_Golden{
 	{0x00000000, ""},
 	{0x00000061, "a"},
@@ -328,6 +362,10 @@ func TestJava(t *testing.T) {
 
 func TestDbj32(t *testing.T) {
 	testGolden(t, NewDjb32(), goldenDjb32, "djb")
+}
+
+func TestDbj32a(t *testing.T) {
+	testGolden(t, NewDjb32a(), goldenDjb32a, "djb2a")
 }
 
 func TestElf32(t *testing.T) {

--- a/stringhashes.go
+++ b/stringhashes.go
@@ -17,17 +17,8 @@ func (sh *javaStringHash32) BlockSize() int { return 1 }
 func (sh *javaStringHash32) Sum32() uint32  { return uint32(*sh) }
 func (sh *javaStringHash32) Reset()         { *sh = javaStringHash32(0) }
 func (sh *javaStringHash32) Sum(b []byte) []byte {
-	p := make([]byte, 4)
-	p[0] = byte(*sh >> 24)
-	p[1] = byte(*sh >> 16)
-	p[2] = byte(*sh >> 8)
-	p[3] = byte(*sh)
-
-	if b == nil {
-		return p
-	}
-
-	return append(b, p...)
+	v := uint32(*sh)
+	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 }
 
 func (sh *javaStringHash32) Write(b []byte) (int, error) {
@@ -48,17 +39,8 @@ func (sh *djb2StringHash32) BlockSize() int { return 1 }
 func (sh *djb2StringHash32) Sum32() uint32  { return uint32(*sh) }
 func (sh *djb2StringHash32) Reset()         { *sh = djb2StringHash32(5381) }
 func (sh *djb2StringHash32) Sum(b []byte) []byte {
-	p := make([]byte, 4)
-	p[0] = byte(*sh >> 24)
-	p[1] = byte(*sh >> 16)
-	p[2] = byte(*sh >> 8)
-	p[3] = byte(*sh)
-
-	if b == nil {
-		return p
-	}
-
-	return append(b, p...)
+	v := uint32(*sh)
+	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 }
 
 func (sh *djb2StringHash32) Write(b []byte) (int, error) {
@@ -67,6 +49,28 @@ func (sh *djb2StringHash32) Write(b []byte) (int, error) {
 		h = 33*h + uint32(c)
 	}
 	*sh = djb2StringHash32(h)
+	return len(b), nil
+}
+
+type djb2aStringHash32 uint32
+
+// NewDjb32a returns a new hash.Hash32 object, computing a variant of Daniel J. Bernstein's hash that uses xor instead of +
+func NewDjb32a() hash.Hash32                 { sh := djb2aStringHash32(0); sh.Reset(); return &sh }
+func (sh *djb2aStringHash32) Size() int      { return 4 }
+func (sh *djb2aStringHash32) BlockSize() int { return 1 }
+func (sh *djb2aStringHash32) Sum32() uint32  { return uint32(*sh) }
+func (sh *djb2aStringHash32) Reset()         { *sh = djb2aStringHash32(5381) }
+func (sh *djb2aStringHash32) Sum(b []byte) []byte {
+	v := uint32(*sh)
+	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+func (sh *djb2aStringHash32) Write(b []byte) (int, error) {
+	h := uint32(*sh)
+	for _, c := range b {
+		h = 33*h ^ uint32(c)
+	}
+	*sh = djb2aStringHash32(h)
 	return len(b), nil
 }
 
@@ -79,17 +83,8 @@ func (sh *elf32StringHash32) BlockSize() int { return 1 }
 func (sh *elf32StringHash32) Sum32() uint32  { return uint32(*sh) }
 func (sh *elf32StringHash32) Reset()         { *sh = elf32StringHash32(0) }
 func (sh *elf32StringHash32) Sum(b []byte) []byte {
-	p := make([]byte, 4)
-	p[0] = byte(*sh >> 24)
-	p[1] = byte(*sh >> 16)
-	p[2] = byte(*sh >> 8)
-	p[3] = byte(*sh)
-
-	if b == nil {
-		return p
-	}
-
-	return append(b, p...)
+	v := uint32(*sh)
+	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 }
 
 func (sh *elf32StringHash32) Write(b []byte) (int, error) {
@@ -115,17 +110,8 @@ func (sh *sdbmStringHash32) BlockSize() int { return 1 }
 func (sh *sdbmStringHash32) Sum32() uint32  { return uint32(*sh) }
 func (sh *sdbmStringHash32) Reset()         { *sh = sdbmStringHash32(0) }
 func (sh *sdbmStringHash32) Sum(b []byte) []byte {
-	p := make([]byte, 4)
-	p[0] = byte(*sh >> 24)
-	p[1] = byte(*sh >> 16)
-	p[2] = byte(*sh >> 8)
-	p[3] = byte(*sh)
-
-	if b == nil {
-		return p
-	}
-
-	return append(b, p...)
+	v := uint32(*sh)
+	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 }
 
 func (sh *sdbmStringHash32) Write(b []byte) (int, error) {
@@ -146,17 +132,8 @@ func (sh *sqlite3StringHash32) BlockSize() int { return 1 }
 func (sh *sqlite3StringHash32) Sum32() uint32  { return uint32(*sh) }
 func (sh *sqlite3StringHash32) Reset()         { *sh = sqlite3StringHash32(0) }
 func (sh *sqlite3StringHash32) Sum(b []byte) []byte {
-	p := make([]byte, 4)
-	p[0] = byte(*sh >> 24)
-	p[1] = byte(*sh >> 16)
-	p[2] = byte(*sh >> 8)
-	p[3] = byte(*sh)
-
-	if b == nil {
-		return p
-	}
-
-	return append(b, p...)
+	v := uint32(*sh)
+	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 }
 
 func (sh *sqlite3StringHash32) Write(b []byte) (int, error) {
@@ -202,18 +179,6 @@ func (sh *jenkinsStringHash32) Sum32() uint32 {
 }
 
 func (sh *jenkinsStringHash32) Sum(b []byte) []byte {
-
-	h := sh.Sum32()
-
-	p := make([]byte, 4)
-	p[0] = byte(h >> 24)
-	p[1] = byte(h >> 16)
-	p[2] = byte(h >> 8)
-	p[3] = byte(h)
-
-	if b == nil {
-		return p
-	}
-
-	return append(b, p...)
+	v := sh.Sum32()
+	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 }


### PR DESCRIPTION
I added an implementation for djb2a which uses xor instead of +. It is mentioned here: http://www.cse.yorku.ca/~oz/hash.html

I also refactored the Sum functions to avoid allocating a byte slice.